### PR TITLE
Add map feature for tracking

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,31 @@
 from flask import Flask, render_template, request, redirect, url_for, session
 import sqlite3
 
+
+def get_coordinates_from_status(status: str):
+    """Return latitude and longitude tuple based on status text."""
+    if not status:
+        return None
+
+    text = status.lower()
+
+    # Mapping of key phrases to coordinates
+    mapping = {
+        "en miami": (25.761681, -80.191788),
+        "en aduana de cuba": (23.1387, -82.3539),
+        "en transito": (23.5, -82.0),
+        # Legacy English phrases kept for compatibility
+        "miami": (25.761681, -80.191788),
+        "havana": (23.1136, -82.3666),
+        "ocean": (24.5, -81.0),
+    }
+
+    for phrase, coords in mapping.items():
+        if phrase in text:
+            return coords
+
+    return None
+
 app = Flask(__name__)
 app.secret_key = 'your_secret_key'
 
@@ -13,6 +38,7 @@ def get_db_connection():
 @app.route('/', methods=['GET', 'POST'])
 def index():
     status = None
+    coords = None
     if request.method == 'POST':
         order_id = request.form['order_id']
         conn = get_db_connection()
@@ -20,9 +46,10 @@ def index():
         conn.close()
         if order:
             status = order['status']
+            coords = get_coordinates_from_status(status)
         else:
             status = 'Tracking code not found.'
-    return render_template('index.html', status=status)
+    return render_template('index.html', status=status, location=coords)
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>ScooterMania Package Tracker</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2CCd7NdN/d1xBnI0so3gc9MMxAaqICxF8r0zPHE=" crossorigin=""/>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -33,6 +34,10 @@
         input[type="submit"] {
             padding: 10px 20px;
         }
+        #map {
+            height: 400px;
+            margin-top: 20px;
+        }
     </style>
 </head>
 <body>
@@ -46,6 +51,21 @@
         {% if status %}
             <p>Status: <strong>{{ status }}</strong></p>
         {% endif %}
+        {% if location %}
+            <div id="map"></div>
+        {% endif %}
     </div>
+    {% if location %}
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7kCnnkA5sjGcXBR7yZ/Kv8G+3SeK2ImFD2bAxA=" crossorigin=""></script>
+    <script>
+        const lat = {{ location[0] }};
+        const lon = {{ location[1] }};
+        const map = L.map('map').setView([lat, lon], 10);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
+        }).addTo(map);
+        L.marker([lat, lon]).addTo(map);
+    </script>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- compute map coordinates from tracking status
- display map on the package tracker page using Leaflet
- map Spanish status phrases to specific coordinates

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6864c60f8f708330aa24da13d5365768